### PR TITLE
feat: Add pagination to family summaries on dashboard

### DIFF
--- a/my_cointrak_api/app/Http/Controllers/FamilyController.php
+++ b/my_cointrak_api/app/Http/Controllers/FamilyController.php
@@ -184,9 +184,9 @@ class FamilyController extends Controller
     public function summaries(Request $request)
     {
         $user = $request->user();
-        $families = $user->families()->with('owner')->get();
+        $families = $user->families()->with('owner')->paginate(2);
 
-        $summaries = $families->map(function ($family) {
+        $families->getCollection()->transform(function ($family){
             $inflow = $family->transactions()->where('type', 'income')->sum('amount');
             $outflow = $family->transactions()->where('type', 'expense')->sum('amount');
 
@@ -200,6 +200,6 @@ class FamilyController extends Controller
             ];
         });
 
-        return response($summaries);
+        return response($families);
     }
 }


### PR DESCRIPTION
- Updates the FamilyController summaries endpoint to use paginate(2).
- Modifies Home.jsx to handle the paginated family summary response.
- Adds state and UI controls for family summary pagination.
- This allows users to browse through all their family ledgers from the dashboard, 2 at a time.